### PR TITLE
Fix HWID script: import only required Microsoft Graph sub-modules

### DIFF
--- a/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
+++ b/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
@@ -17,11 +17,21 @@ New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 $AppName = "Intune HWID Upload ($MspName)"
 $SecretLifetimeDays = 730
 
-# Ensure Graph module
-if (-not (Get-Module -ListAvailable -Name Microsoft.Graph)) {
-    Install-Module Microsoft.Graph -Scope CurrentUser -Force
+# Ensure required Microsoft Graph sub-modules.
+# Importing the full Microsoft.Graph meta-module is slow and frequently fails
+# to load its RequiredModules (e.g. "Microsoft.Graph.Authentication is not
+# loaded"). The script only needs these three, so install/import them directly.
+$GraphModules = @(
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Applications",
+    "Microsoft.Graph.Identity.DirectoryManagement"
+)
+foreach ($m in $GraphModules) {
+    if (-not (Get-Module -ListAvailable -Name $m)) {
+        Install-Module $m -Scope CurrentUser -Force -AllowClobber
+    }
+    Import-Module $m -Force
 }
-Import-Module Microsoft.Graph
 
 $scopes = @(
   "Application.ReadWrite.All",


### PR DESCRIPTION
## Problem
Running the HWID app-registration script (via `irm https://hwid.it2.sh/<MspName> | iex`) fails at module load:

```
Import-Module Microsoft.Graph
  The required module 'Microsoft.Graph.Authentication' is not loaded...
  The required module 'Microsoft.Graph.Applications' is not loaded...
```

`Import-Module Microsoft.Graph` loads the full umbrella meta-module, which routinely fails to bring in its `RequiredModules` (and is slow / hits function-count limits).

## Fix
Install and import only the three sub-modules the script actually uses:
- `Microsoft.Graph.Authentication` — `Connect-MgGraph`, `Get-MgContext`
- `Microsoft.Graph.Applications` — `*-MgApplication*`, `*-MgServicePrincipal*`
- `Microsoft.Graph.Identity.DirectoryManagement` — `Get-MgDomain`

This loads cleanly and quickly, avoiding the meta-module dependency problem.

## Impact
`hwid.it2.sh` serves this script live from `main`, so once merged the fix takes effect immediately — no Worker change needed.

https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C)_