### PR TITLE
Fix empty AppId/AppSecret in generated OOBE script

### DIFF
--- a/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
+++ b/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
@@ -131,7 +131,7 @@ try {
 
 Install-Script -Name Get-WindowsAutoPilotInfo -Force -Scope AllUsers
 
-Get-WindowsAutoPilotInfo -Online -TenantId $TenantID -AppId $ApplicationID -AppSecret $ApplicationSecret
+Get-WindowsAutoPilotInfo -Online -TenantId `$TenantID -AppId `$ApplicationID -AppSecret `$ApplicationSecret
 
 Write-Host "HWID upload completed successfully." -ForegroundColor Green
 "@


### PR DESCRIPTION
## Problem
The generated `*-Intune-HWID-OOBE.ps1` failed at runtime:

```
Get-WindowsAutopilotInfo.ps1: ... -AppId  -AppSecret …
  Missing an argument for parameter 'AppId'.
```

In the OOBE here-string, the final `Get-WindowsAutoPilotInfo` line referenced `$ApplicationID` and `$ApplicationSecret` **unescaped**, so they were expanded at *generation* time against the outer script's scope — where those variables don't exist — and written out blank. (`$TenantID` happened to fill in only because PowerShell is case-insensitive and matched the outer `$tenantId`.)

## Fix
Escape the three variables on that line so they resolve at *runtime* of the generated script, where `$TenantID` / `$ApplicationID` / `$ApplicationSecret` are defined just above:

```powershell
Get-WindowsAutoPilotInfo -Online -TenantId `$TenantID -AppId `$ApplicationID -AppSecret `$ApplicationSecret
```

## Impact
`hwid.it2.sh` serves this script live from `main`, so once merged the generated OOBE script will have a valid `-AppId`/`-AppSecret` and the HWID upload will work.

https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C)_