### PR TITLE
Reuse existing HWID app registration instead of creating duplicates

### DIFF
--- a/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
+++ b/EndpointManager/Enrollment/Generate-AppRegistrationHWID.ps1
@@ -81,20 +81,36 @@ $requiredResourceAccess = @(
   }
 )
 
-# Create App + SP
-$app = New-MgApplication -DisplayName $AppName -RequiredResourceAccess $requiredResourceAccess
-$sp  = New-MgServicePrincipal -AppId $app.AppId
+# Reuse an existing app of the same name instead of creating duplicates.
+# Single quotes in the name are escaped for the OData filter.
+$filterName = $AppName -replace "'", "''"
+$app = Get-MgApplication -Filter "displayName eq '$filterName'" -All -ErrorAction SilentlyContinue | Select-Object -First 1
 
-# Long-lived secret
+if ($app) {
+    Write-Host "Existing app found, reusing it: $($app.AppId)" -ForegroundColor Yellow
+    $sp = Get-MgServicePrincipal -Filter "appId eq '$($app.AppId)'" -ErrorAction SilentlyContinue
+    if (-not $sp) { $sp = New-MgServicePrincipal -AppId $app.AppId }
+} else {
+    # Create App + SP
+    $app = New-MgApplication -DisplayName $AppName -RequiredResourceAccess $requiredResourceAccess
+    $sp  = New-MgServicePrincipal -AppId $app.AppId
+}
+
+# Long-lived secret (a fresh one is added on every run)
 $endDate = (Get-Date).AddDays($SecretLifetimeDays)
 $pwd = Add-MgApplicationPassword -ApplicationId $app.Id -PasswordCredential @{
-    displayName = "OOBE-HWID-Secret"
+    displayName = "OOBE-HWID-Secret $((Get-Date).ToString('yyyy-MM-dd'))"
     endDateTime = $endDate
 }
 
-# Grant admin consent
+# Grant admin consent (skip role assignments that already exist)
 Write-Host "Granting admin consent..." -ForegroundColor Cyan
+$existingAssignments = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $sp.Id -All -ErrorAction SilentlyContinue
 foreach ($role in $roles) {
+    $already = $existingAssignments | Where-Object {
+        $_.AppRoleId -eq $role.Id -and $_.ResourceId -eq $graphSp.Id
+    }
+    if ($already) { continue }
     New-MgServicePrincipalAppRoleAssignment `
         -ServicePrincipalId $sp.Id `
         -PrincipalId $sp.Id `


### PR DESCRIPTION
## Problem
The script created a new app registration on every run (`New-MgApplication` was unconditional), so re-running it for the same MSP produced duplicate apps all named `Intune HWID Upload (<MSP>)`, each with its own secret and consent grant.

## Change
Make runs idempotent — **reuse the existing app and add a fresh secret** (the chosen behavior):

- Look up the app by display name (`Get-MgApplication -Filter "displayName eq '...'"`, with single quotes escaped for OData). If found, reuse it and its service principal (creating the SP only if missing); otherwise create app + SP as before.
- Always add a **new** secret on each run (dated display name `OOBE-HWID-Secret <yyyy-MM-dd>`). Existing secrets are left valid until they expire.
- Skip app-role assignments that already exist, so re-running doesn't pile up duplicate consent grants.

Net result: one app per MSP, no duplicates, and re-running safely issues a fresh secret + regenerates the OOBE script.

## Impact
`hwid.it2.sh` serves this live from `main`, so the new behavior takes effect on merge.

https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9MF43RXhif6iU75xvsa4C)_